### PR TITLE
Remove reliance on multiprocessing manager from ProteinNet parser

### DIFF
--- a/scripts/proteinnet2pytorch.py
+++ b/scripts/proteinnet2pytorch.py
@@ -36,21 +36,44 @@ from protein_transformer.protein.structure_exceptions import \
 
 pr.confProDy(verbosity='error')
 m = multiprocessing.Manager()
-SEQUENCE_ERRORS = m.list()
-MULTIPLE_CONTIG_ERRORS = m.list()
-FAILED_ASTRAL_IDS = m.list()
-PARSING_ERRORS = m.list()
-NSAA_ERRORS = m.list()
-MISSING_ASTRAL_IDS = m.list()
-SHORT_ERRORS = m.list()
-PARSING_ERROR_ATTRIBUTE = m.list()
-PARSING_ERROR = m.list()
-PARSING_ERROR_OSERROR = m.list()
-UNKNOWN_EXCEPTIONS = m.list()
-MISSING_ATOMS_ERROR = m.list()
-NONE_STRUCTURE_ERRORS = m.list()
-NONE_CHAINS = m.list()
-NO_PBD_FILE = m.list()
+ERRORS = ["SEQUENCE_ERRORS", "MULTIPLE_CONTIG_ERRORS", "FAILED_ASTRAL_IDS", "PARSING_ERRORS", "NSAA_ERRORS", "MISSING_ASTRAL_IDS", "SHORT_ERRORS", "PARSING_ERROR_ATTRIBUTE", "PARSING_ERROR", "PARSING_ERROR_OSERROR", "UNKNOWN_EXCEPTIONS", "MISSING_ATOMS_ERROR", "NONE_STRUCTURE_ERRORS", "NONE_CHAINS", "NO_PBD_FILE"]
+
+class ProteinErrors(object):
+    """ A simple, flexible class to record and report errors when parsing. """
+    def __init__(self):
+        self.descr_to_codes = {}
+        self.counts = None
+        for e in ERRORS:
+            self[e]
+
+    def __getitem__(self, error_descr):
+        """
+        Returns the error code for a certain error description. If not
+        present, it adds the error to its dictionary.
+        """
+        if error_descr in self.descr_to_codes:
+            return self.descr_to_codes[error_descr]
+        else:
+            self.descr_to_codes[error_descr] = len(self.descr_to_codes)
+            return self.descr_to_codes[error_descr]
+
+    def count(self, ec, pnid):
+        """ Creates a record of a certain PNID exhibiting a certain error. """
+        if not self.counts:
+            self.counts = {ec: [] for ec in self.descr_to_codes.values()}
+
+        self.counts[ec].append(pnid)
+
+
+    def summarize(self):
+        """ Prints a summary of all errors that have been recorded."""
+        assert self.counts, "Errors must be counted before being summarized."
+        self.error_codes_inv = {v: k for k, v in self.descr_to_codes.items()}
+        for error_code, count_list in self.counts.items():
+            print(f"{len(count_list)} {self.error_codes_inv[error_code]}")
+
+
+ERRORS = ProteinErrors()
 
 def get_chain_from_trainid(proteinnet_id):
     """
@@ -67,14 +90,11 @@ def get_chain_from_trainid(proteinnet_id):
             pdbid, astral_id = proteinnet_id.split("_")
             return get_chain_from_astral_id(astral_id.replace("-", "_"), ASTRAL_ID_MAPPING)
         except KeyError:
-            MISSING_ASTRAL_IDS.append(proteinnet_id)
-            return None
+            return ERRORS["MISSING_ASTRAL_IDS"]
         except ValueError:
-            FAILED_ASTRAL_IDS.append(proteinnet_id)
-            return None
+            return ERRORS["FAILED_ASTRAL_IDS"]
         except:
-            FAILED_ASTRAL_IDS.append(proteinnet_id)
-            return None
+            return ERRORS["FAILED_ASTRAL_IDS"]
 
     # Continue loading the chain, given the PDB ID
     try:
@@ -83,22 +103,17 @@ def get_chain_from_trainid(proteinnet_id):
         try:
             chain = pr.parseCIF(pdbid, chain=chid) # changed pr.parsePDB to pr.parseCIF, removed heirarchal view
         except AttributeError:
-            PARSING_ERROR_ATTRIBUTE.append(proteinnet_id)
-            return None
+            return ERRORS["PARSING_ERROR_ATTRIBUTE"]
         except pr.proteins.pdbfile.PDBParseError:
-            PARSING_ERROR.append(proteinnet_id)
-            return None
+            return ERRORS["PARSING_ERROR"]
         except OSError:
-            PARSING_ERROR_OSERROR.append(proteinnet_id)
-            return None
+            return ERRORS["PARSING_ERROR_OSERROR"]
         except Exception as e:
-            UNKNOWN_EXCEPTIONS.append(str(e) + " " + proteinnet_id)
-            return None
+            return ERRORS["UNKNOWN_EXCEPTIONS"]
 
     if chain is None:
         print(proteinnet_id)
-        NONE_CHAINS.append(proteinnet_id)
-        return None
+        return ERRORS["NONE_CHAINS"]
     # Attempt to select a coordset
     try:
         if chain.numCoordsets() > 1:
@@ -120,8 +135,7 @@ def get_chain_from_testid(proteinnet_id):
     try:
         pdb_hv = pr.parsePDB(os.path.join(args.input_dir, "targets", caspid + ".pdb")).getHierView() # TODO change to pr.parseCIF?
     except AttributeError:
-        PARSING_ERRORS.append(proteinnet_id)
-        return None
+        return ERRORS["PARSING_ERRORS"]
     try:
         assert pdb_hv.numChains() == 1
     except:
@@ -166,36 +180,29 @@ def work(pdbid_chain):
     true_seq = get_proteinnet_seq_from_id(pdbid_chain) # TODO replace this function that returns chain from file w/ seq
     chain = get_chain_from_proteinnetid(pdbid_chain)  # Returns ProDy chain object
     if not chain:
-        NONE_STRUCTURE_ERRORS.append(pdbid_chain)
-        return None
+        return ERRORS["NONE_STRUCTURE_ERRORS"]
     try:
         dihedrals_coords_sequence = get_seq_and_masked_coords_and_angles(chain, true_seq)
     except NonStandardAminoAcidError:
-        NSAA_ERRORS.append(pdbid_chain)
-        return None
+        return ERRORS["NSAA_ERRORS"]
     except NoneStructureError:
-        NONE_STRUCTURE_ERRORS.append(pdbid_chain)
-        return None
+        return ERRORS["NONE_STRUCTURE_ERRORS"]
     except ContigMultipleMatchingError:
-        MULTIPLE_CONTIG_ERRORS.append(pdbid_chain)
-        return None
+        return ERRORS["MULTIPLE_CONTIG_ERRORS"]
     except ShortStructureError:
-        SHORT_ERRORS.append(pdbid_chain)
-        return None
+        return ERRORS["SHORT_ERRORS"]
     except MissingAtomsError:
-        MISSING_ATOMS_ERROR.append(pdbid_chain)
-        return None
+        return ERRORS["MISSING_ATOMS_ERROR"]
     except SequenceError:
         print("Not fixed.", pdbid_chain)
-        SEQUENCE_ERRORS.append(pdbid_chain)
-        return None
+        return ERRORS["SEQUENCE_ERRORS"]
 
     # If we've made it this far, we can unpack the data and return it
     dihedrals, coords, sequence = dihedrals_coords_sequence
 
     return dihedrals, coords, sequence, pdbid_chain
 
-def unpack_processed_results(results):
+def unpack_processed_results(results, pnids):
     """
     Given an iterable of processed results containing angles, sequences, and PDB IDs,
     this function separates out the components (sequences as one-hot vectors, angle matrices,
@@ -206,10 +213,10 @@ def unpack_processed_results(results):
     all_crds = []
     all_ids = []
     c = 0
-    for r in results:
-        if not r:
+    for r, pnid in zip(results, pnids):
+        if type(r) == int:
             # PDB failed to download
-            continue
+            ERRORS.count(r, pnid)
         ang, coords, seq, i = r
         if  no_nans_infs_allzeros(ang) and no_nans_infs_allzeros(coords):
             all_ohs.append(seq)
@@ -410,16 +417,17 @@ def main():
         test_results.append(work(tid))
 
     print("Structures processed.")
-    print_failure_summary()
+    
 
     # Unpack results
     print("Training set:\t", end="")
-    train_ohs, train_angs, train_strs, train_ids = unpack_processed_results(train_results)
-    for split, results in valid_result_meta.items():
+    train_ohs, train_angs, train_strs, train_ids = unpack_processed_results(train_results, train_pdb_ids[:lim])
+    for (split, results), vids in zip(valid_result_meta.items(), group_validation_set(valid_ids).values()):
         print(f"Valid set {split}%:\t", end="")
-        valid_result_meta[split] = unpack_processed_results(results)
+        valid_result_meta[split] = unpack_processed_results(results, vids[:vlim])
     print("Test set:\t\t", end="")
-    test_ohs, test_angs, test_strs, test_ids = unpack_processed_results(test_results)
+    test_ohs, test_angs, test_strs, test_ids = unpack_processed_results(test_results, test_casp_ids[:vlim])
+    print_failure_summary()
 
     # Split into train, test and validation sets. Report sizes.
     data = create_data_dict(train_ohs, test_ohs, train_angs, test_angs, train_strs, test_strs, train_ids, test_ids,
@@ -430,62 +438,48 @@ def main():
 
 def print_failure_summary():
     """ Summarizes failures associated with the processing of ProteinNet ID data. """
-    print(f"{len(MISSING_ASTRAL_IDS)} ASTRAL IDs were missing from the file.")
-    print(f"{len(FAILED_ASTRAL_IDS)} ASTRAL IDs failed to download for another reason.")
-    print(f"{len(MULTIPLE_CONTIG_ERRORS)} ProteinNet IDs failed because of multiple matching contigs.")
-    print(f"{len(SEQUENCE_ERRORS)} ProteinNet IDs failed because of mismatching sequence errors.")
-    print(f"{len(NSAA_ERRORS)} ProteinNet IDs failed because of non-std AAs.")
-    print(f"{len(SHORT_ERRORS)} ProteinNet IDs failed because their length was <= 2.")
-    print(f"{len(PARSING_ERRORS)} ProteinNet IDs failed because of parsing errors.")
-    print(f"{len(PARSING_ERROR_ATTRIBUTE)} ProteinNet IDs failed because of attribute errors.")
-    print(f"{len(PARSING_ERROR)} ProteinNet IDs failed because of standard parsing error.")
-    print(f"{len(PARSING_ERROR_OSERROR)} ProteinNet IDs failed because of OSError.")
-    print(f"{len(UNKNOWN_EXCEPTIONS)} ProteinNet IDs failed because of unknown OSError.")
-    print(f"{len(MISSING_ATOMS_ERROR)} ProteinNet IDs failed because residues were missing N, CA1, or C atoms.")
-    print(f"{len(NONE_CHAINS)} ProteinNet IDs failed because no chain existed.")
-    print(f"{len(NO_PBD_FILE)} ProteinNet IDs failed because no PDB file exists and they probably have .CIF instead.")
-    print(f"{len(NONE_STRUCTURE_ERRORS)} ProteinNet IDs failed because chain become `None`.")
+    ERRORS.summarize()
 
-    os.makedirs("errors/", exist_ok=True)
-    with open('errors/MISSING_ASTRAL_IDS.txt', 'w') as f:
-        f.write('\n'.join(MISSING_ASTRAL_IDS))
-    with open('errors/FAILED_ASTRAL_IDS.txt', 'w') as f:
-        f.write('\n'.join(FAILED_ASTRAL_IDS))
-    with open('errors/MULTIPLE_CONTIG_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(MULTIPLE_CONTIG_ERRORS))
-    with open('errors/SEQUENCE_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(SEQUENCE_ERRORS))
-    with open('errors/NSAA_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(NSAA_ERRORS))
-    with open('errors/SHORT_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(SHORT_ERRORS))
-    #Total number of parsing errors, may not be needed
-    with open('errors/PARSING_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(PARSING_ERRORS))
-    #Added to split up the three category of parsing errors, this one handles attribute errors
-    with open('errors/PARSING_ERROR_ATTRIBUTE.txt', 'w') as f:
-        f.write('\n'.join(PARSING_ERROR_ATTRIBUTE))
-    #Added to handle 'regular' parsing errors
-    with open('errors/PARSING_ERROR.txt', 'w') as f:
-        f.write('\n'.join(PARSING_ERROR))
-    #Added to handle OS related parsing errors
-    with open('errors/PARSING_ERROR_OSERROR.txt', 'w') as f:
-        f.write('\n'.join(PARSING_ERROR_OSERROR))
+    # os.makedirs("errors/", exist_ok=True)
+    # with open('errors/MISSING_ASTRAL_IDS.txt', 'w') as f:
+    #     f.write('\n'.join(MISSING_ASTRAL_IDS))
+    # with open('errors/FAILED_ASTRAL_IDS.txt', 'w') as f:
+    #     f.write('\n'.join(FAILED_ASTRAL_IDS))
+    # with open('errors/MULTIPLE_CONTIG_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(MULTIPLE_CONTIG_ERRORS))
+    # with open('errors/SEQUENCE_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(SEQUENCE_ERRORS))
+    # with open('errors/NSAA_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(NSAA_ERRORS))
+    # with open('errors/SHORT_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(SHORT_ERRORS))
+    # #Total number of parsing errors, may not be needed
+    # with open('errors/PARSING_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(PARSING_ERRORS))
+    # #Added to split up the three category of parsing errors, this one handles attribute errors
+    # with open('errors/PARSING_ERROR_ATTRIBUTE.txt', 'w') as f:
+    #     f.write('\n'.join(PARSING_ERROR_ATTRIBUTE))
+    # #Added to handle 'regular' parsing errors
+    # with open('errors/PARSING_ERROR.txt', 'w') as f:
+    #     f.write('\n'.join(PARSING_ERROR))
+    # #Added to handle OS related parsing errors
+    # with open('errors/PARSING_ERROR_OSERROR.txt', 'w') as f:
+    #     f.write('\n'.join(PARSING_ERROR_OSERROR))
 
-    #Added for cases where pr.parseCIF returned unknown exception in function get_chain_from_trainid(proteinnet_id)
-    with open('errors/UNKNOWN_EXCEPTION.txt', 'w') as f:
-        f.write('\n'.join(UNKNOWN_EXCEPTIONS))
-    #Added for cases where measure_phi_psi_omega or measure_bond_angles fail due to missing atom information
-    with open('errors/MISSING_ATOMS_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(MISSING_ATOMS_ERROR))
-    #Added when chain variable returned 'none' in function get_chain_from_trainid(proteinnet_id)
-    with open('errors/NONE_CHAINS.txt', 'w') as f:
-        f.write('\n'.join(NONE_CHAINS))
-    #Added to handle when no PDB file existed for entry
-    with open('errors/NO_PDB_FILE.txt', 'w') as f:
-        f.write('\n'.join(NO_PBD_FILE))
-    with open('errors/NONE_STRUCTURE_ERRORS.txt', 'w') as f:
-        f.write('\n'.join(NONE_STRUCTURE_ERRORS))
+    # #Added for cases where pr.parseCIF returned unknown exception in function get_chain_from_trainid(proteinnet_id)
+    # with open('errors/UNKNOWN_EXCEPTION.txt', 'w') as f:
+    #     f.write('\n'.join(UNKNOWN_EXCEPTIONS))
+    # #Added for cases where measure_phi_psi_omega or measure_bond_angles fail due to missing atom information
+    # with open('errors/MISSING_ATOMS_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(MISSING_ATOMS_ERROR))
+    # #Added when chain variable returned 'none' in function get_chain_from_trainid(proteinnet_id)
+    # with open('errors/NONE_CHAINS.txt', 'w') as f:
+    #     f.write('\n'.join(NONE_CHAINS))
+    # #Added to handle when no PDB file existed for entry
+    # with open('errors/NO_PDB_FILE.txt', 'w') as f:
+    #     f.write('\n'.join(NO_PBD_FILE))
+    # with open('errors/NONE_STRUCTURE_ERRORS.txt', 'w') as f:
+    #     f.write('\n'.join(NONE_STRUCTURE_ERRORS))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/scripts/proteinnet_errors.py
+++ b/scripts/proteinnet_errors.py
@@ -1,0 +1,86 @@
+import os
+
+ERROR_CODES = [("SEQUENCE_ERRORS", "structures failed because of an unresolvable issue with sequences."),
+               ("MULTIPLE_CONTIG_ERRORS", "structures failed to parse because they had ambiguous sequence "
+                                          "alignments/multiple identical contigs."),
+               ("FAILED_ASTRAL_IDS", "Astral IDs failed to parse for some unknown reason."),
+               ("TEST_PARSING_ERRORS", "test structures experience AttributeErrors when parsing."),
+               ("NSAA_ERRORS", "structures failed because they had non-standard amino acids."),
+               ("MISSING_ASTRAL_IDS", "Astral IDs could not be found in the lookup file."),
+               ("SHORT_ERRORS", "structures failed because they were too short."),
+               ("PARSING_ERROR_ATTRIBUTE", "structures experienced AttributeErrors when parsing PDB/mmCIF files."),
+               ("PARSING_ERROR", "structures experienced `pr.proteins.pdbfile.PDBParseError` when parsing PDB/mmCIF "
+                                 "files."),
+               ("PARSING_ERROR_OSERROR", "structures experienced OSErrors when parsing PDB/mmCIF files."),
+               ("UNKNOWN_EXCEPTIONS", "structures experienced Unknown exceptions when parsing PDB/mmCIF files."),
+               ("MISSING_ATOMS_ERROR", "structures failed because they had missing atoms."),
+               ("NONE_STRUCTURE_ERRORS", "structures were returned as None from subroutine."),
+               ("NONE_CHAINS", "chains became none when parsing."),
+               ("COORDSET_INDEX_ERROR", "structures failed to correctly select ACSIndex.")]
+
+
+class ProteinErrors(object):
+    """
+    A simple, flexible class to record and report errors when parsing.
+
+    For each type of error, this class records the error's name (a short, descriptive title),
+    the error's description, and an integer error code.
+
+    The reason for implementing this extra class is that when using multiprocessing to process all the structures,
+    the processes are free to fail by raising any type of special exception.  To communicate this information back
+    to the parent process, we create a simple mapping from error to code/description so that these can be shown to
+    the user.
+    """
+    def __init__(self):
+        self.name_to_code = {}
+        self.name_to_descr = {}
+        self.counts = None
+        for i, (error_name, error_descr) in enumerate(ERROR_CODES):
+            self.name_to_code[error_name] = i
+            self.name_to_descr[error_name] = error_descr
+
+    def __getitem__(self, error_name):
+        """ Returns the error code for a certain error name. """
+        return self.name_to_code[error_name]
+
+    def count(self, ec, pnid):
+        """ Creates a record of a certain PNID exhibiting a certain error. """
+        if not self.counts:
+            self.counts = {ec: [] for ec in self.name_to_code.values()}
+
+        self.counts[ec].append(pnid)
+
+    def summarize(self):
+        """ Prints a summary of all errors that have been recorded."""
+        if not self.counts:
+            print("Errors have not been accounted for.")
+            return
+
+        print("\nThe following errors occurred:")
+        self.error_codes_inv = {v: k for k, v in self.name_to_code.items()}
+        for error_code, count_list in self.counts.items():
+            if len(count_list) > 0:
+                name = self.error_codes_inv[error_code]
+                descr = self.name_to_descr[name]
+                print(f"{name + ':':<25}{len(count_list):^8}{descr}")
+        print("")
+        self.write_summary_files()
+
+    def get_pnids_with_error_name(self, error_name):
+        """ After counting, returns a list of pnids that have failed with a specified error code. """
+        error_code = self[error_name]
+        return self.counts[error_code]
+
+    def get_error_names(self):
+        """ Returns a list of error names. """
+        return self.name_to_code.keys()
+
+    def write_summary_files(self):
+        """ For all counted errors, writes the list of pnids with each error to the errors/ directory. """
+        os.makedirs("errors/", exist_ok=True)
+        for e in self.get_error_names():
+            if len(self.get_pnids_with_error_name(e)) > 0:
+                with open(f"errors/{e}.txt", "w") as f:
+                    f.write("\n".join(self.get_pnids_with_error_name(e)) + "\n")
+
+ERRORS = ProteinErrors()


### PR DESCRIPTION
## Description
Removed unnecessary use of multiprocessing manager when reporting error codes. Instead, created a separate class to define and report errors. 
